### PR TITLE
Feat: API 랜덤 이미지 생성 후 ImageView에 넣기

### DIFF
--- a/PokemonPhoneBook/PokemonAPI/PokemonModel.swift
+++ b/PokemonPhoneBook/PokemonAPI/PokemonModel.swift
@@ -1,0 +1,25 @@
+//
+//  PokemonModel.swift
+//  PokemonPhoneBook
+//
+//  Created by oww on 9/29/25.
+//
+
+import Foundation
+
+struct PokemonModel: Codable{
+    
+    let sprites: Sprites
+}
+
+class Sprites: Codable {
+    let frontDefault: String
+    
+    enum CodingKeys: String, CodingKey {
+         case frontDefault = "front_default"
+     }
+    
+    init(frontDefault: String) {
+        self.frontDefault = frontDefault
+    }
+}

--- a/PokemonPhoneBook/PokemonAPI/PokemonSpriteFetch.swift
+++ b/PokemonPhoneBook/PokemonAPI/PokemonSpriteFetch.swift
@@ -1,0 +1,48 @@
+//
+//  PokemonSpriteFetch.swift
+//  PokemonPhoneBook
+//
+//  Created by oww on 9/29/25.
+//
+
+import Foundation
+import UIKit
+import Alamofire
+
+class PokemonSpriteFetch{
+    
+    private func fetchDataByAlamofire<T: Decodable>(url: URL, completion: @escaping (Result<T, AFError>) -> Void){
+            AF.request(url).responseDecodable(of: T.self){ response in
+                completion(response.result)}
+        }
+    
+    func fetchPokemonSprite(completion: @escaping(UIImage?) -> Void){
+        let randomNums = Int.random(in: 1...1000)
+        let urlComponents = URLComponents(string: "https://pokeapi.co/api/v2/pokemon/\(randomNums)")
+        
+        guard let url = urlComponents?.url else{
+            print("잘못된 URL")
+            completion(nil)
+            return
+        }
+        
+        fetchDataByAlamofire(url: url){(result: Result<PokemonModel, AFError>) in
+            switch result{
+            case .success(let result):
+                let imageURL = result.sprites.frontDefault
+                
+                AF.request(imageURL).responseData{ response in
+                    if let data = response.data, let image = UIImage(data: data){
+                        completion(image)
+                    } else {
+                        completion(nil)
+                    }
+                }
+            case .failure(let error):
+                print("데이터 로드 실패: \(error)")
+            }
+        }
+    }
+    
+    
+}

--- a/PokemonPhoneBook/Scenes/ViewControllers/AddContactVC.swift
+++ b/PokemonPhoneBook/Scenes/ViewControllers/AddContactVC.swift
@@ -12,6 +12,7 @@ import SnapKit
 class AddContactVC:UIViewController{
     
     let addView = AddContactView()
+    let pokemonSpriteFetcher = PokemonSpriteFetch()
     
     override func loadView() {
         super.loadView()
@@ -26,8 +27,14 @@ class AddContactVC:UIViewController{
         setupUI()
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        addView.randomIMG.image = nil
+    }
     private func configureView(){
         view.addSubview(addView)
+        
+        addView.randomImgButton.addTarget(self, action: #selector(randomImgButtonTapped), for: .touchUpInside)
     }
     
     private func setupUI(){
@@ -43,6 +50,15 @@ class AddContactVC:UIViewController{
     
     @objc func saveButtonTapped(){
         
+    }
+    
+    @objc func randomImgButtonTapped(){
+        print("buttonTap")
+        pokemonSpriteFetcher.fetchPokemonSprite{
+            [weak self] image in DispatchQueue.main.async{
+                self?.addView.randomIMG.image = image
+            }
+        }
     }
 }
 #Preview{


### PR DESCRIPTION
PokemonModel.swift
API 명세를 파악하고 가져올 JSON 데이터를 위한 Codable 구조체 선언

PokemonSpriteFetch.swift
HTTP 네트워킹 라이브러리인 Alamofire를 활용하여 네트워킹 통신 수행
1~1000랜덤 포켓몬 이미지 가져오기

```swift
 let randomNums = Int.random(in: 1...1000)
 let urlComponents = URLComponents(string: "https://pokeapi.co/api/v2/pokemon/\(randomNums)")
``` 